### PR TITLE
BeMain/issue9

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,19 @@
+import 'package:audio_service/audio_service.dart';
 import 'package:flutter/material.dart';
 import 'package:musbx/metronome/bottom_bar.dart';
+import 'package:musbx/music_player/audio_handler.dart';
 import 'package:musbx/music_player/music_player_screen.dart';
-import 'package:musbx/tuner/tuner_screen.dart';
 
-void main() {
+Future<void> main() async {
+  // Create audio service
+  await AudioService.init(
+    builder: () => MyAudioHandler.instance,
+    config: const AudioServiceConfig(
+      androidNotificationChannelId: 'se.agardh.musbx.channel.audio',
+      androidNotificationChannelName: 'Musbx',
+    ),
+  );
+
   runApp(const MyApp());
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,7 +9,7 @@ Future<void> main() async {
   // Create audio service
   MusicPlayer.instance = MusicPlayer.internal(
     await AudioService.init(
-      builder: () => MyAudioHandler(),
+      builder: () => JustAudioHandler(),
       config: const AudioServiceConfig(
         androidNotificationChannelId: 'se.agardh.musbx.channel.audio',
         androidNotificationChannelName: 'Musbx',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,15 +2,18 @@ import 'package:audio_service/audio_service.dart';
 import 'package:flutter/material.dart';
 import 'package:musbx/metronome/bottom_bar.dart';
 import 'package:musbx/music_player/audio_handler.dart';
+import 'package:musbx/music_player/music_player.dart';
 import 'package:musbx/music_player/music_player_screen.dart';
 
 Future<void> main() async {
   // Create audio service
-  await AudioService.init(
-    builder: () => MyAudioHandler.instance,
-    config: const AudioServiceConfig(
-      androidNotificationChannelId: 'se.agardh.musbx.channel.audio',
-      androidNotificationChannelName: 'Musbx',
+  MusicPlayer.instance = MusicPlayer.internal(
+    await AudioService.init(
+      builder: () => MyAudioHandler(),
+      config: const AudioServiceConfig(
+        androidNotificationChannelId: 'se.agardh.musbx.channel.audio',
+        androidNotificationChannelName: 'Musbx',
+      ),
     ),
   );
 

--- a/lib/music_player/audio_handler.dart
+++ b/lib/music_player/audio_handler.dart
@@ -3,15 +3,16 @@ import 'dart:async';
 import 'package:audio_service/audio_service.dart';
 import 'package:just_audio/just_audio.dart';
 
-/// Uses just_audio to handle playback.
-/// Inherit to override getMediaItem, if you want to get metadata from a media id.
 class JustAudioHandler extends BaseAudioHandler with SeekHandler {
-  // Only way to access is through [instance]
+  /// Interface to the audio notification.
+  ///
+  /// Uses just_audio to handle playback.
   JustAudioHandler() {
     // Notify AudioHandler about playback events from AudioPlayer.
     player.playbackEventStream.map(_transformEvent).pipe(playbackState);
   }
 
+  /// The [AudioPlayer] used for playback.
   final AudioPlayer player = AudioPlayer();
 
   @override
@@ -36,6 +37,7 @@ class JustAudioHandler extends BaseAudioHandler with SeekHandler {
     await player.setSpeed(speed);
   }
 
+  /// Transform an event from just_audio's AudioPlayer to audio_service's AudioHandler.
   PlaybackState _transformEvent(PlaybackEvent event) {
     final isCompleted = (player.processingState == ProcessingState.completed);
 

--- a/lib/music_player/audio_handler.dart
+++ b/lib/music_player/audio_handler.dart
@@ -2,29 +2,23 @@ import 'dart:async';
 
 import 'package:audio_service/audio_service.dart';
 import 'package:just_audio/just_audio.dart';
-import 'package:musbx/music_player/music_player.dart';
 
 /// Uses just_audio to handle playback.
 /// Inherit to override getMediaItem, if you want to get metadata from a media id.
 class MyAudioHandler extends BaseAudioHandler with SeekHandler {
   // Only way to access is through [instance]
-  MyAudioHandler._internal() {
+  MyAudioHandler() {
     // Notify AudioHandler about playback events from AudioPlayer.
     player.playbackEventStream.map(_transformEvent).pipe(playbackState);
   }
 
-  /// The instance of this singleton.
-  static final MyAudioHandler instance = MyAudioHandler._internal();
-
-  final MusicPlayer player = MusicPlayer.instance;
+  final AudioPlayer player = AudioPlayer();
 
   @override
-  Future<void> play() => player.play();
+  Future<void> play() async => await player.play();
 
   @override
-  Future<void> pause() async {
-    await player.pause();
-  }
+  Future<void> pause() async => await player.pause();
 
   @override
   Future<void> stop() async {
@@ -64,7 +58,6 @@ class MyAudioHandler extends BaseAudioHandler with SeekHandler {
         ProcessingState.ready: AudioProcessingState.ready,
         ProcessingState.completed: AudioProcessingState.ready,
       }[player.processingState]!,
-      // If completed, audioPlayer might say playing, but really we aren't.
       playing: player.playing && !isCompleted,
       updatePosition: player.position,
       bufferedPosition: player.bufferedPosition,

--- a/lib/music_player/audio_handler.dart
+++ b/lib/music_player/audio_handler.dart
@@ -1,0 +1,74 @@
+import 'dart:async';
+
+import 'package:audio_service/audio_service.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:musbx/music_player/music_player.dart';
+
+/// Uses just_audio to handle playback.
+/// Inherit to override getMediaItem, if you want to get metadata from a media id.
+class MyAudioHandler extends BaseAudioHandler with SeekHandler {
+  // Only way to access is through [instance]
+  MyAudioHandler._internal() {
+    // Notify AudioHandler about playback events from AudioPlayer.
+    player.playbackEventStream.map(_transformEvent).pipe(playbackState);
+  }
+
+  /// The instance of this singleton.
+  static final MyAudioHandler instance = MyAudioHandler._internal();
+
+  final MusicPlayer player = MusicPlayer.instance;
+
+  @override
+  Future<void> play() => player.play();
+
+  @override
+  Future<void> pause() async {
+    await player.pause();
+  }
+
+  @override
+  Future<void> stop() async {
+    await player.stop();
+    await super.stop();
+  }
+
+  @override
+  Future<void> seek(Duration position) async {
+    await player.seek(position);
+  }
+
+  @override
+  Future<void> setSpeed(double speed) async {
+    await player.setSpeed(speed);
+  }
+
+  PlaybackState _transformEvent(PlaybackEvent event) {
+    final isCompleted = (player.processingState == ProcessingState.completed);
+
+    return PlaybackState(
+      controls: [
+        MediaControl.rewind,
+        if (player.playing) MediaControl.pause else MediaControl.play,
+        MediaControl.fastForward,
+      ],
+      systemActions: const {
+        MediaAction.seek,
+        MediaAction.seekBackward,
+        MediaAction.seekForward,
+      },
+      androidCompactActionIndices: const [0, 1],
+      processingState: const {
+        ProcessingState.idle: AudioProcessingState.idle,
+        ProcessingState.loading: AudioProcessingState.loading,
+        ProcessingState.buffering: AudioProcessingState.buffering,
+        ProcessingState.ready: AudioProcessingState.ready,
+        ProcessingState.completed: AudioProcessingState.ready,
+      }[player.processingState]!,
+      // If completed, audioPlayer might say playing, but really we aren't.
+      playing: player.playing && !isCompleted,
+      updatePosition: player.position,
+      bufferedPosition: player.bufferedPosition,
+      speed: player.speed,
+    );
+  }
+}

--- a/lib/music_player/audio_handler.dart
+++ b/lib/music_player/audio_handler.dart
@@ -5,9 +5,9 @@ import 'package:just_audio/just_audio.dart';
 
 /// Uses just_audio to handle playback.
 /// Inherit to override getMediaItem, if you want to get metadata from a media id.
-class MyAudioHandler extends BaseAudioHandler with SeekHandler {
+class JustAudioHandler extends BaseAudioHandler with SeekHandler {
   // Only way to access is through [instance]
-  MyAudioHandler() {
+  JustAudioHandler() {
     // Notify AudioHandler about playback events from AudioPlayer.
     player.playbackEventStream.map(_transformEvent).pipe(playbackState);
   }

--- a/lib/music_player/button_panel.dart
+++ b/lib/music_player/button_panel.dart
@@ -9,10 +9,10 @@ class ButtonPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final MusicPlayer player = MusicPlayer.instance;
+    final MusicPlayer musicPlayer = MusicPlayer.instance;
 
     return ValueListenableBuilder(
-      valueListenable: player.songTitleNotifier,
+      valueListenable: musicPlayer.songTitleNotifier,
       builder: (context, songTitle, child) {
         return Row(
           mainAxisAlignment: MainAxisAlignment.center,
@@ -21,28 +21,27 @@ class ButtonPanel extends StatelessWidget {
               onPressed: (songTitle == null)
                   ? null
                   : () {
-                      player.seek(player.position - const Duration(seconds: 1));
+                      musicPlayer.seek(musicPlayer.positionNotifier.value -
+                          const Duration(seconds: 1));
                     },
               onLongPress: (songTitle == null)
                   ? null
                   : () {
-                      player.seek(Duration.zero);
+                      musicPlayer.seek(Duration.zero);
                     },
               child: const Icon(Icons.fast_rewind_rounded, size: 40),
             ),
-            StreamBuilder<bool>(
-              stream: player.playingStream,
-              initialData: false,
-              builder: (context, snapshot) {
-                bool isPlaying = snapshot.data!;
+            ValueListenableBuilder<bool>(
+              valueListenable: musicPlayer.isPlayingNotifier,
+              builder: (context, isPlaying, child) {
                 return TextButton(
                   onPressed: (songTitle == null)
                       ? null
                       : () {
                           if (isPlaying) {
-                            player.pause();
+                            musicPlayer.pause();
                           } else {
-                            player.play();
+                            musicPlayer.play();
                           }
                         },
                   child: Icon(
@@ -56,7 +55,8 @@ class ButtonPanel extends StatelessWidget {
               onPressed: (songTitle == null)
                   ? null
                   : () {
-                      player.seek(player.position + const Duration(seconds: 1));
+                      musicPlayer.seek(musicPlayer.positionNotifier.value +
+                          const Duration(seconds: 1));
                     },
               child: const Icon(Icons.fast_forward_rounded, size: 40),
             ),

--- a/lib/music_player/music_player.dart
+++ b/lib/music_player/music_player.dart
@@ -1,7 +1,10 @@
 import 'dart:math';
 
+import 'package:audio_service/audio_service.dart';
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:just_audio/just_audio.dart';
+import 'package:musbx/music_player/audio_handler.dart';
 
 /// Singleton for playing songs.
 class MusicPlayer extends AudioPlayer {
@@ -21,5 +24,15 @@ class MusicPlayer extends AudioPlayer {
   /// Set how much the pitch will be shifted, in semitones.
   Future<void> setPitchSemitones(double semitones) async {
     await setPitch(pow(2, semitones / 12).toDouble());
+  }
+
+  Future<void> playFile(PlatformFile file) async {
+    songTitle = file.name;
+    await setFilePath(file.path!);
+    MyAudioHandler.instance.mediaItem.add(MediaItem(
+      id: file.path!,
+      title: file.name,
+      duration: duration,
+    ));
   }
 }

--- a/lib/music_player/music_player.dart
+++ b/lib/music_player/music_player.dart
@@ -3,36 +3,98 @@ import 'dart:math';
 import 'package:audio_service/audio_service.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
-import 'package:just_audio/just_audio.dart';
 import 'package:musbx/music_player/audio_handler.dart';
 
 /// Singleton for playing songs.
-class MusicPlayer extends AudioPlayer {
-  MusicPlayer._internal(); // Only way to access is through [instance]
-
-  /// The instance of this singleton.
-  static final MusicPlayer instance = MusicPlayer._internal();
-
-  /// Title of the current song. If no song is loaded, will return `null`.
-  String? get songTitle => songTitleNotifier.value;
-  set songTitle(String? value) => songTitleNotifier.value = value;
-  ValueNotifier<String?> songTitleNotifier = ValueNotifier<String?>(null);
-
-  /// How much the pitch will be shifted, in semitones.
-  double get pitchSemitones => (12 * log(pitch) / log(2)).toDouble();
-
-  /// Set how much the pitch will be shifted, in semitones.
-  Future<void> setPitchSemitones(double semitones) async {
-    await setPitch(pow(2, semitones / 12).toDouble());
+class MusicPlayer {
+  // Should only be accessed through [instance]
+  MusicPlayer.internal(this._audioHandler) {
+    _listenForChanges();
   }
 
+  /// The instance of this singleton.
+  static late final MusicPlayer instance;
+
+  /// The AudioHandler used internally to play sound.
+  final MyAudioHandler _audioHandler;
+
+  /// Start or resume playback.
+  Future<void> play() async => await _audioHandler.play();
+
+  /// Pause playback.
+  Future<void> pause() async => await _audioHandler.pause();
+
+  /// Seek to [position].
+  Future<void> seek(Duration position) async {
+    await _audioHandler.seek(position);
+  }
+
+  /// Set the playback speed.
+  Future<void> setSpeed(double speed) async {
+    await _audioHandler.setSpeed(speed);
+  }
+
+  /// Title of the current song or `null` if no song loaded.
+  final ValueNotifier<String?> songTitleNotifier = ValueNotifier<String?>(null);
+
+  /// How much the pitch will be shifted, in semitones.
+  final ValueNotifier<double> pitchSemitonesNotifier = ValueNotifier(0);
+
+  /// The current speed of the player.
+  final ValueNotifier<double> speedNotifier = ValueNotifier(1);
+
+  /// The current position of the player.
+  final ValueNotifier<Duration> positionNotifier = ValueNotifier(Duration.zero);
+
+  /// The buffered position of the player.
+  final ValueNotifier<Duration> bufferedPositionNotifier =
+      ValueNotifier(Duration.zero);
+
+  /// The duration of the current audio or null if unknown.
+  final ValueNotifier<Duration?> durationNotifier = ValueNotifier(null);
+
+  /// Whether the player is playing.
+  final ValueNotifier<bool> isPlayingNotifier = ValueNotifier(false);
+
+  /// Play [file].
   Future<void> playFile(PlatformFile file) async {
-    songTitle = file.name;
-    await setFilePath(file.path!);
-    MyAudioHandler.instance.mediaItem.add(MediaItem(
+    await _audioHandler.player.setFilePath(file.path!);
+    _audioHandler.mediaItem.add(MediaItem(
       id: file.path!,
       title: file.name,
-      duration: duration,
+      duration: _audioHandler.player.duration,
     ));
+  }
+
+  /// Listen for changes from [_audioHandler].
+  void _listenForChanges() {
+    // bufferedPosition & isPlaying & speed
+    _audioHandler.playbackState.listen((newState) {
+      bufferedPositionNotifier.value = newState.bufferedPosition;
+      isPlayingNotifier.value = newState.playing;
+      speedNotifier.value = newState.speed;
+    });
+
+    // position
+    AudioService.position.listen((position) {
+      positionNotifier.value = position;
+    });
+
+    // duration & songTitle
+    _audioHandler.mediaItem.listen((mediaItem) {
+      durationNotifier.value = mediaItem?.duration ?? Duration.zero;
+      songTitleNotifier.value = mediaItem?.title;
+    });
+
+    // pitch
+    _audioHandler.player.pitchStream.listen((pitch) {
+      pitchSemitonesNotifier.value = (12 * log(pitch) / log(2)).toDouble();
+    });
+
+    // Update AudioPlayer's pitch when it changes.
+    pitchSemitonesNotifier.addListener(() async {
+      await _audioHandler.player
+          .setPitch(pow(2, pitchSemitonesNotifier.value / 12).toDouble());
+    });
   }
 }

--- a/lib/music_player/music_player.dart
+++ b/lib/music_player/music_player.dart
@@ -16,7 +16,7 @@ class MusicPlayer {
   static late final MusicPlayer instance;
 
   /// The AudioHandler used internally to play sound.
-  final MyAudioHandler _audioHandler;
+  final JustAudioHandler _audioHandler;
 
   /// Start or resume playback.
   Future<void> play() async => await _audioHandler.play();

--- a/lib/music_player/music_player.dart
+++ b/lib/music_player/music_player.dart
@@ -5,9 +5,9 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:musbx/music_player/audio_handler.dart';
 
-/// Singleton for playing songs.
+/// Singleton for playing audio.
 class MusicPlayer {
-  // Should only be accessed through [instance]
+  // Should only be accessed through [instance].
   MusicPlayer.internal(this._audioHandler) {
     _listenForChanges();
   }
@@ -34,7 +34,7 @@ class MusicPlayer {
     await _audioHandler.setSpeed(speed);
   }
 
-  /// Title of the current song or `null` if no song loaded.
+  /// Title of the current song, or `null` if no song loaded.
   final ValueNotifier<String?> songTitleNotifier = ValueNotifier<String?>(null);
 
   /// How much the pitch will be shifted, in semitones.
@@ -50,13 +50,13 @@ class MusicPlayer {
   final ValueNotifier<Duration> bufferedPositionNotifier =
       ValueNotifier(Duration.zero);
 
-  /// The duration of the current audio or null if unknown.
+  /// The duration of the current audio, or null if no audio has been loaded.
   final ValueNotifier<Duration?> durationNotifier = ValueNotifier(null);
 
   /// Whether the player is playing.
   final ValueNotifier<bool> isPlayingNotifier = ValueNotifier(false);
 
-  /// Play [file].
+  /// Play a [PlatformFile].
   Future<void> playFile(PlatformFile file) async {
     await _audioHandler.player.setFilePath(file.path!);
     _audioHandler.mediaItem.add(MediaItem(

--- a/lib/music_player/music_player_screen.dart
+++ b/lib/music_player/music_player_screen.dart
@@ -22,7 +22,7 @@ class MusicPlayerScreen extends StatefulWidget {
 }
 
 class MusicPlayerScreenState extends State<MusicPlayerScreen> {
-  final MusicPlayer player = MusicPlayer.instance;
+  final MusicPlayer musicPlayer = MusicPlayer.instance;
 
   @override
   Widget build(BuildContext context) {
@@ -53,13 +53,12 @@ class MusicPlayerScreenState extends State<MusicPlayerScreen> {
 
   Widget buildPitchSlider() {
     return StreamSlider(
-      stream: player.pitchStream
-          .map((double pitch) => (12 * log(pitch) / log(2)).roundToDouble()),
+      listenable: musicPlayer.pitchSemitonesNotifier,
       onChangeEnd: (double value) {
-        player.setPitchSemitones(value);
+        musicPlayer.pitchSemitonesNotifier.value = value;
       },
       onClear: () {
-        player.setPitchSemitones(0);
+        musicPlayer.pitchSemitonesNotifier.value = 0;
       },
       min: -9,
       max: 9,
@@ -71,12 +70,12 @@ class MusicPlayerScreenState extends State<MusicPlayerScreen> {
 
   Widget buildSpeedSlider() {
     return StreamSlider(
-      stream: player.speedStream,
+      listenable: musicPlayer.speedNotifier,
       onChangeEnd: (double value) {
-        player.setSpeed(value);
+        musicPlayer.setSpeed(value);
       },
       onClear: () {
-        player.setSpeed(1.0);
+        musicPlayer.setSpeed(1.0);
       },
       min: 0.1,
       max: 1.9,

--- a/lib/music_player/pick_song_button.dart
+++ b/lib/music_player/pick_song_button.dart
@@ -15,8 +15,7 @@ class PickSongButton extends StatelessWidget {
         );
 
         if (result != null && result.files.single.path != null) {
-          await MusicPlayer.instance.setFilePath(result.files.single.path!);
-          MusicPlayer.instance.songTitle = result.files.single.name;
+          await MusicPlayer.instance.playFile(result.files.single);
         }
       },
       child: const Icon(Icons.file_upload_rounded),

--- a/lib/music_player/position_slider.dart
+++ b/lib/music_player/position_slider.dart
@@ -11,7 +11,7 @@ class PositionSlider extends StatefulWidget {
 }
 
 class PositionSliderState extends State<PositionSlider> {
-  final MusicPlayer player = MusicPlayer.instance;
+  final MusicPlayer musicPlayer = MusicPlayer.instance;
 
   Duration _position = Duration.zero;
 
@@ -23,8 +23,8 @@ class PositionSliderState extends State<PositionSlider> {
 
     if (_position.isNegative) _position = Duration.zero; // Clamp lower
     // Clamp higher
-    if (_position > (player.duration ?? Duration.zero)) {
-      _position = player.duration ?? Duration.zero;
+    if (_position > (musicPlayer.durationNotifier.value ?? Duration.zero)) {
+      _position = musicPlayer.durationNotifier.value ?? Duration.zero;
     }
   }
 
@@ -33,16 +33,16 @@ class PositionSliderState extends State<PositionSlider> {
     super.initState();
 
     // When a new song is loaded, rebuild
-    player.durationStream.listen((final Duration? duration) {
+    musicPlayer.durationNotifier.addListener(() {
       setState(() {
         position = Duration.zero;
       });
     });
 
     // When position changes, update it locally
-    player.positionStream.listen((final Duration position) {
+    musicPlayer.positionNotifier.addListener(() {
       setState(() {
-        this.position = position;
+        position = musicPlayer.positionNotifier.value;
       });
     });
   }
@@ -50,7 +50,7 @@ class PositionSliderState extends State<PositionSlider> {
   @override
   Widget build(BuildContext context) {
     return ValueListenableBuilder(
-      valueListenable: player.songTitleNotifier,
+      valueListenable: musicPlayer.songTitleNotifier,
       builder: (context, songTitle, child) {
         return Row(
           children: [
@@ -58,7 +58,9 @@ class PositionSliderState extends State<PositionSlider> {
             Expanded(
               child: Slider(
                 min: 0,
-                max: player.duration?.inSeconds.roundToDouble() ?? 1,
+                max: musicPlayer.durationNotifier.value?.inSeconds
+                        .roundToDouble() ??
+                    1,
                 value: position.inSeconds.roundToDouble(),
                 onChanged: (songTitle == null)
                     ? null
@@ -68,11 +70,11 @@ class PositionSliderState extends State<PositionSlider> {
                         });
                       },
                 onChangeEnd: (double value) {
-                  player.seek(position);
+                  musicPlayer.seek(position);
                 },
               ),
             ),
-            _buildDurationText(player.duration),
+            _buildDurationText(musicPlayer.durationNotifier.value),
           ],
         );
       },

--- a/lib/music_player/stream_slider.dart
+++ b/lib/music_player/stream_slider.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 class StreamSlider extends StatefulWidget {
@@ -8,7 +9,7 @@ class StreamSlider extends StatefulWidget {
   /// the user changes the slider or the stream changes.
   const StreamSlider({
     super.key,
-    required this.stream,
+    required this.listenable,
     this.onChanged,
     this.onChangeEnd,
     this.onClear,
@@ -20,7 +21,7 @@ class StreamSlider extends StatefulWidget {
   });
 
   /// The stream to listen to. Updates whenever this changes.
-  final Stream<double> stream;
+  final ValueListenable<double> listenable;
 
   /// Called during a drag when the user is selecting a new value for the slider by dragging.
   /// See [Slider.onChanged]
@@ -63,10 +64,10 @@ class StreamSliderState extends State<StreamSlider> {
     super.initState();
 
     // Rebuild whenever [widget.stream] updates
-    widget.stream.listen((newValue) {
-      if (value != newValue) {
+    widget.listenable.addListener(() {
+      if (value != widget.listenable.value) {
         setState(() {
-          value = newValue;
+          value = widget.listenable.value;
         });
       }
     });

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,16 +5,20 @@
 import FlutterMacOS
 import Foundation
 
+import audio_service
 import audio_session
 import audioplayers
 import just_audio
 import mic_stream
 import path_provider_macos
+import sqflite
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  AudioServicePlugin.register(with: registry.registrar(forPlugin: "AudioServicePlugin"))
   AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
   AudioplayersPlugin.register(with: registry.registrar(forPlugin: "AudioplayersPlugin"))
   JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))
   MicStreamPlugin.register(with: registry.registrar(forPlugin: "MicStreamPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -281,7 +281,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
@@ -517,7 +517,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.1"
+    version: "1.9.0"
   sqflite:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -29,6 +29,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.9.0"
+  audio_service:
+    dependency: "direct main"
+    description:
+      name: audio_service
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.18.7"
+  audio_service_platform_interface:
+    dependency: transitive
+    description:
+      name: audio_service_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0"
+  audio_service_web:
+    dependency: transitive
+    description:
+      name: audio_service_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.1"
   audio_session:
     dependency: transitive
     description:
@@ -125,6 +146,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_cache_manager:
+    dependency: transitive
+    description:
+      name: flutter_cache_manager
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.3.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -246,14 +274,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
@@ -345,6 +373,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  pedantic:
+    dependency: transitive
+    description:
+      name: pedantic
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.11.1"
   permission_handler:
     dependency: transitive
     description:
@@ -482,7 +517,21 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
+  sqflite:
+    dependency: transitive
+    description:
+      name: sqflite
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.3+1"
+  sqflite_common:
+    dependency: transitive
+    description:
+      name: sqflite_common
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.1+1"
   stack_trace:
     dependency: transitive
     description:
@@ -504,6 +553,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.1"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.0+2"
   term_glyph:
     dependency: transitive
     description:
@@ -517,21 +573,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.21.1"
+    version: "1.21.4"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.12"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.13"
+    version: "0.4.16"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   gauges: ^1.0.0
   pitch_detector_dart: ^0.0.2
   mic_stream: ^0.6.1
+  audio_service: ^0.18.7
 
 
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
A notification for controlling AudioPlayer, similar to what Spotify does.

JustAudioHandler uses just_audio's AudioPlayer under the hood to play audio, and is responsible for controlling the notification.
MusicPlayer is the app's interface to the JustAudioHandler. Changes in JustAudioHandler are forwarded to MusicPlayer and vice versa.