### PR TITLE
Change the range of the speed slider to between 0.5 and 2

### DIFF
--- a/lib/music_player/pitch_speed_card/circular_slider/circular_slider.dart
+++ b/lib/music_player/pitch_speed_card/circular_slider/circular_slider.dart
@@ -25,7 +25,7 @@ class CircularSlider extends StatefulWidget {
     this.label,
     this.min = 0.0,
     this.max = 1.0,
-    this.divisions,
+    this.divisionValues,
     this.outerRadius = 50,
     this.startAngle = -2.0,
     this.endAngle = 2.0,
@@ -55,15 +55,13 @@ class CircularSlider extends StatefulWidget {
   /// change state until the parent widget rebuilds the slider with the new
   /// value.
   ///
-  /// [continuous] is true if the value was selected during a continuous selection.
-  ///
   /// If null, the slider will be displayed as disabled.
-  final void Function(double value, bool continuous)? onChanged;
+  final void Function(double value)? onChanged;
 
-  /// The number of discrete divisions.
+  /// The values on the slider where divisions are placed.
   ///
   /// If null, the slider is continuous.
-  final int? divisions;
+  final List<double>? divisionValues;
 
   /// Widget displayed in the center of the slider.
   final Widget? label;
@@ -135,7 +133,9 @@ class CircularSliderState extends State<CircularSlider> {
           activeFraction: activeFraction,
           startAngle: widget.startAngle,
           endAngle: widget.endAngle,
-          divisions: widget.divisions,
+          divisions: widget.divisionValues
+              ?.map((value) => (value - widget.min) / (widget.max - widget.min))
+              .toList(),
           dragging: dragging,
           disabled: widget.onChanged == null,
         ),
@@ -179,10 +179,21 @@ class CircularSliderState extends State<CircularSlider> {
         (angle - widget.startAngle) / (widget.endAngle - widget.startAngle);
     double newValue = fraction * (widget.max - widget.min) + widget.min;
 
-    bool continuous = (localPosition - center).distance <
-        radius + widget.continuousSelectionDistance;
+    if (widget.divisionValues != null &&
+        (localPosition - center).distance <
+            radius + widget.continuousSelectionDistance) {
+      // Snap value to nearest division
+      double nearestDivisionValue = widget.divisionValues![0];
+      for (double divisionValue in widget.divisionValues!) {
+        if ((newValue - divisionValue).abs() <
+            (newValue - nearestDivisionValue).abs()) {
+          nearestDivisionValue = divisionValue;
+        }
+      }
+      newValue = nearestDivisionValue;
+    }
 
-    widget.onChanged?.call(newValue, continuous);
+    widget.onChanged?.call(newValue);
   }
 
   /// Convert global [position] to local coordinate space.

--- a/lib/music_player/pitch_speed_card/circular_slider/painter.dart
+++ b/lib/music_player/pitch_speed_card/circular_slider/painter.dart
@@ -37,8 +37,8 @@ class CircularSliderPainter extends CustomPainter {
   /// The theme specifying colors for the slider.
   final CircularSliderTheme theme;
 
-  /// The number of discrete divisions, if any.
-  final int? divisions;
+  /// The values on the slider where divisions are placed, if any.
+  final List<double>? divisions;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -87,9 +87,9 @@ class CircularSliderPainter extends CustomPainter {
         ..color = disabled
             ? theme.disabledInactiveTickMarkColor
             : theme.inactiveTickMarkColor;
-      for (int i = 0; i <= divisions!; i++) {
-        double angle =
-            startAngle - pi / 2 + (endAngle - startAngle) * (i / divisions!);
+
+      for (double value in divisions!) {
+        double angle = startAngle - pi / 2 + (endAngle - startAngle) * value;
         Offset offset = angleToPoint(angle, center, radius);
         canvas.drawCircle(offset, theme.trackHeight / 4,
             (angle < thumbAngle) ? activeTickMarkPaint : inactiveTickMarkPaint);

--- a/lib/music_player/pitch_speed_card/pitch_speed_card.dart
+++ b/lib/music_player/pitch_speed_card/pitch_speed_card.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:musbx/music_player/music_player.dart';
 import 'package:musbx/music_player/pitch_speed_card/circular_slider/circular_slider.dart';
@@ -43,20 +45,15 @@ class PitchSpeedCard extends StatelessWidget {
           value: pitch,
           min: -12,
           max: 12,
-          divisions: 24,
+          divisionValues: List.generate(25, (i) => i - 12.0),
           outerRadius: radius,
           label: Text(
             ((pitch >= 0) ? "+" : "-") + pitch.abs().toStringAsFixed(1),
             style: Theme.of(context).textTheme.displaySmall,
           ),
           onChanged: musicPlayer.nullIfNoSongElse(
-            (double value, bool continuous) {
-              if (continuous) {
-                value = value.roundToDouble();
-              } else {
-                value = (value * 10).roundToDouble() / 10;
-              }
-              musicPlayer.setPitchSemitones(value);
+            (double value) {
+              musicPlayer.setPitchSemitones((value * 10).roundToDouble() / 10);
             },
           ),
         ),
@@ -78,21 +75,21 @@ class PitchSpeedCard extends StatelessWidget {
       valueListenable: musicPlayer.speedNotifier,
       builder: (context, speed, _) => Stack(children: [
         CircularSlider(
-          value: speed,
-          min: 0.1,
-          max: 1.9,
-          divisions: 18,
+          value: sqrt(speed - 7 / 16) - 0.25,
+          min: 0,
+          max: 1,
+          divisionValues: List.generate(
+                  21, (i) => (i <= 10) ? 0.5 + i / 20 : 0.5 - 10 / 20 + i / 10)
+              .map((speedValue) => sqrt(speedValue - 7 / 16) - 0.25)
+              .toList(),
           outerRadius: radius,
           label: Text(
             speed.toStringAsFixed(2),
             style: Theme.of(context).textTheme.displaySmall,
           ),
           onChanged: musicPlayer.nullIfNoSongElse(
-            (double value, bool continuous) {
-              if (continuous) {
-                value = (value * 10).roundToDouble() / 10;
-              }
-              musicPlayer.setSpeed(value);
+            (double value) {
+              musicPlayer.setSpeed(pow(value, 2) + value / 2 + 0.5);
             },
           ),
         ),


### PR DESCRIPTION
Use a quadratic function to set the range of the speed slider to between 0.5 and 2, while keeping the center value at 1.

Pass a list of values that divisions are placed at to CircularSlider instead of just how many divisions to create,
so that the divisions of the speed slider can be placed at regular intervals.