### PR TITLE
Demixer - Mix wav files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "search.exclude": {
+        "**/.git": true,
+        "**/*.svg": true,
+    },
+}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.8.22'
+    ext.kotlin_version = '1.9.10'
     repositories {
         google()
         mavenCentral()

--- a/lib/music_player/demixer/demixer.dart
+++ b/lib/music_player/demixer/demixer.dart
@@ -104,7 +104,10 @@ class Demixer extends MusicPlayerComponent {
     Song? song = musicPlayer.song;
     if (song == null) return;
 
-    await onEnabledToggle();
+    // Ugly way to force just_audio to perform a new request to MixedAudioSource, so that changes to stems are detected.
+    Duration position = musicPlayer.position;
+    await musicPlayer.seek(position - const Duration(seconds: 1));
+    await musicPlayer.seek(position);
   }
 
   Future<void> onNewSongLoaded() async {

--- a/lib/music_player/demixer/demixer.dart
+++ b/lib/music_player/demixer/demixer.dart
@@ -62,16 +62,9 @@ class Demixer extends MusicPlayerComponent {
   @override
   void initialize(MusicPlayer musicPlayer) {
     musicPlayer.songNotifier.addListener(onNewSongLoaded);
-    musicPlayer.equalizer.parametersNotifier.addListener(onEqualizerChanged);
     enabledNotifier.addListener(onEnabledToggle);
 
     stemsNotifier.addListener(onStemsChanged);
-
-    musicPlayer.equalizer.enabledNotifier.addListener(() {
-      // For now, disable when demixer is enabled since they don't work together.
-      // TODO: Get the Demixer to work with the Equalizer.
-      if (musicPlayer.equalizer.enabled) enabled = false;
-    });
   }
 
   Future<void> demixCurrentSong() async {
@@ -121,19 +114,6 @@ class Demixer extends MusicPlayerComponent {
     if (!enabled) return;
 
     await demixCurrentSong();
-  }
-
-  Future<void> onEqualizerChanged() async {
-    // TODO: Get this to work. Currently, there is no trigger for when the Equalizer's parameters changes.
-    // var musicPlayerBands = MusicPlayer.instance.equalizer.parameters?.bands;
-    // if (musicPlayerBands == null) return;
-
-    // for (Stem stem in stems) {
-    //   var bands = (await stem.equalizer.parameters).bands;
-    //   for (int i = 0; i < bands.length; i++) {
-    //     await bands[i].setGain(musicPlayerBands[i].gain);
-    //   }
-    // }
   }
 
   /// The audio loaded to [MusicPlayer] before the Demixer was enabled.

--- a/lib/music_player/demixer/demixer.dart
+++ b/lib/music_player/demixer/demixer.dart
@@ -160,6 +160,7 @@ class Demixer extends MusicPlayerComponent {
         MixedAudioSource(files),
         initialPosition: position,
       );
+      await musicPlayer.player.setVolume(1.0);
     } else {
       // Restore "normal" audio
       if (musicPlayer.song == null) return;
@@ -167,12 +168,16 @@ class Demixer extends MusicPlayerComponent {
         await musicPlayer.song!.source.toAudioSource(),
         initialPosition: position,
       );
+      await musicPlayer.player.setVolume(0.5);
     }
 
     // Update loopSection to avoid error if new audio source isn't exectly as long as the previous.
-    musicPlayer.looper.section = LoopSection(
-      end: musicPlayer.player.duration ?? const Duration(seconds: 1),
-    );
+    if (musicPlayer.song == null) return;
+    Duration newDuration = musicPlayer.player.duration!;
+    if (musicPlayer.looper.section.end.compareTo(newDuration) > 0) {
+      // Section end is greater than new duration
+      musicPlayer.looper.section = LoopSection(end: newDuration);
+    }
   }
 
   /// Load settings from a [json] map.

--- a/lib/music_player/demixer/demixer.dart
+++ b/lib/music_player/demixer/demixer.dart
@@ -3,9 +3,11 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:just_audio/just_audio.dart';
+import 'package:musbx/music_player/demixer/demixer_api.dart';
 import 'package:musbx/music_player/demixer/demixer_api_exceptions.dart';
 import 'package:musbx/music_player/demixer/demixing_process.dart';
 import 'package:musbx/music_player/demixer/host.dart';
+import 'package:musbx/music_player/demixer/mixed_audio_source.dart';
 import 'package:musbx/music_player/demixer/stem.dart';
 import 'package:musbx/music_player/music_player.dart';
 import 'package:musbx/music_player/music_player_component.dart';
@@ -231,8 +233,13 @@ class Demixer extends MusicPlayerComponent {
     if (enabled) {
       originalAudio = musicPlayer.player.audioSource;
       // Disable "normal" audio
+      Directory directory = await DemixerApi.getSongDirectory(song.id);
+      List<File> files = StemType.values
+          .map((stem) => File("${directory.path}/${stem.name}.wav"))
+          .toList();
+
       await musicPlayer.player.setAudioSource(
-        SilenceAudioSource(duration: stems.first.player.duration!),
+        MixedAudioSource(files),
         initialPosition: position,
       );
     } else {

--- a/lib/music_player/demixer/demixer_api.dart
+++ b/lib/music_player/demixer/demixer_api.dart
@@ -7,14 +7,13 @@ import 'package:path_provider/path_provider.dart';
 
 class DemixerApi {
   /// The version of the server that this is compatible with.
-  static const String version = "1.0";
+  static const String version = "1.1";
 
   /// The server hosting the Demixer API.
   static const List<Host> _hosts = [
-    // Host("192.168.1.174:4242"),
-    // Host("musbx-demixer-gpb4qgoxha-lz.a.run.app", https: true),
-    Host("musbx.agardh.se:4242"),
+    // Host("192.168.1.88:4242"),
     Host("brunnby.homeip.net:4242"),
+    Host("musbx.agardh.se:4242"),
   ];
 
   /// The directory where stems are saved.

--- a/lib/music_player/demixer/demixer_card.dart
+++ b/lib/music_player/demixer/demixer_card.dart
@@ -42,12 +42,12 @@ class DemixerCard extends StatelessWidget {
 
                                 musicPlayer.demixer.enabled = value;
                               },
-                    onResetPressed: stems.every(
-                            (Stem stem) => stem.enabled && stem.volume == 0.5)
+                    onResetPressed: stems.every((Stem stem) =>
+                            stem.enabled && stem.volume == Stem.defaultVolume)
                         ? null
                         : () {
                             for (Stem stem in stems) {
-                              stem.volume = 0.5;
+                              stem.volume = Stem.defaultVolume;
                               stem.enabled = true;
                             }
                           },

--- a/lib/music_player/demixer/demixer_card.dart
+++ b/lib/music_player/demixer/demixer_card.dart
@@ -253,15 +253,16 @@ class StemControls extends StatefulWidget {
 class StemControlsState extends State<StemControls> {
   MusicPlayer musicPlayer = MusicPlayer.instance;
 
-  double volume = 0;
+  late double volume = widget.stem.volume;
   void updateVolume() {
-    volume = widget.stem.volume;
+    setState(() {
+      volume = widget.stem.volume;
+    });
   }
 
   @override
   void initState() {
     widget.stem.volumeNotifier.addListener(updateVolume);
-    updateVolume();
     super.initState();
   }
 

--- a/lib/music_player/demixer/demixer_card.dart
+++ b/lib/music_player/demixer/demixer_card.dart
@@ -248,18 +248,27 @@ Please update to the latest version to use the Demixer.""",
 }
 
 class StemControls extends StatefulWidget {
+  /// Widget for enabling/disabling and changing the volume of [stem].
   const StemControls({super.key, required this.stem});
 
   @override
   State<StatefulWidget> createState() => StemControlsState();
 
+  /// The stem this widget controls.
   final Stem stem;
 }
 
 class StemControlsState extends State<StemControls> {
   MusicPlayer musicPlayer = MusicPlayer.instance;
 
+  /// The volume of the stem.
+  ///
+  /// Note that this doesn't always equal [widget.stem.volume], as this value is
+  /// changed whenever the user drags the volume slider but [widget.stem.volume]
+  /// is only updated once the user is done selecting a value.
   late double volume = widget.stem.volume;
+
+  /// Update [volume] to equal [widget.stem.volume]
   void updateVolume() {
     setState(() {
       volume = widget.stem.volume;

--- a/lib/music_player/demixer/mixed_audio_source.dart
+++ b/lib/music_player/demixer/mixed_audio_source.dart
@@ -1,0 +1,51 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:musbx/music_player/demixer/demixer_api.dart';
+import 'package:musbx/music_player/demixer/host.dart';
+import 'package:wav/wav.dart';
+
+class MixedAudioSource extends StreamAudioSource {
+  /// An [AudioSource] that mixes multiple .wav files.
+  ///
+  /// All [wavs] must have the same duration
+  MixedAudioSource(this.wavs) : super(tag: 'MixedAudioSource') {
+    assert(wavs.every((wav) => wav.duration == wavs[0].duration),
+        "All wavs must have the same duration");
+  }
+
+  final List<Wav> wavs;
+
+  @override
+  Future<StreamAudioResponse> request([int? start, int? end]) async {
+    print("[DEMIXER] Request");
+    int sourceLength = (wavs[0].duration * wavs[0].samplesPerSecond).toInt();
+
+    return StreamAudioResponse(
+      sourceLength: sourceLength,
+      contentLength: (end ?? sourceLength) - (start ?? 0),
+      offset: start ?? 0,
+      stream: Stream.fromIterable(
+          [wavs[0].channels[0].buffer.asInt64List().sublist(start ?? 0, end)]),
+      contentType: 'audio/wav',
+    );
+  }
+}
+
+List<int> mixWavs(List<Wav> wavs) {
+  /// The bytes of [wavs] converted to mono.
+  List<Float64List> wavsBytes = wavs.map((wav) => wav.toMono()).toList();
+
+  assert(
+      wavsBytes
+          .skip(1)
+          .every((wavBytes) => wavBytes.length == wavsBytes.first.length),
+      "All wavs must have the same number of bytes");
+
+  int nWavs = wavs.length;
+  return List.generate(wavsBytes.first.length, (i) {
+    // TODO: Consider volume of each wav
+    return wavsBytes.fold(0.0, (sum, wavBytes) => sum + wavBytes[i]) ~/ nWavs;
+  });
+}

--- a/lib/music_player/demixer/mixed_audio_source.dart
+++ b/lib/music_player/demixer/mixed_audio_source.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:async/async.dart';
+import 'package:flutter/foundation.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:musbx/music_player/demixer/demixer.dart';
 import 'package:musbx/music_player/demixer/host.dart';
@@ -43,61 +44,71 @@ class MixedAudioSource extends StreamAudioSource {
       contentType: 'audio/wav',
     );
   }
+
+  /// Mix multiple `wav` files together by taking the average value of each byte.
+  ///
+  /// 16 bits per sample and the files having identical headers is assumed.
+  /// TODO: Check header for audio format (16, 32 bit...)
+  List<int> mixWavFiles(List<StemFileData> dataLists) {
+    Demixer demixer = MusicPlayer.instance.demixer;
+    List<Stem> enabledStems =
+        demixer.stems.where((stem) => stem.enabled).toList();
+
+    // Try to detect wav header
+    // This method isn't fool proof (might by accident be these bytes at the start of the audio sample...) but it works for now
+    bool headerPresent = dataLists.every((stemFileData) =>
+        listEquals(
+          stemFileData.fileData.sublist(0, 4), [82, 73, 70, 70], // RIFF
+        ) &&
+        listEquals(stemFileData.fileData.sublist(8, 16),
+            [87, 65, 86, 69, 102, 109, 116, 32] // WAVEfmt
+            ));
+
+    List<List<double>> listsToMix = [];
+    for (Stem stem in enabledStems) {
+      StemFileData stemFileData = dataLists
+          .where((stemFileData) => stemFileData.stemType == stem.type)
+          .first;
+
+      List<int> data = headerPresent
+          ? stemFileData.fileData.sublist(44) // Remove header
+          : stemFileData.fileData;
+
+      // Convert byte lists from 8 bit to 16 bit
+      Uint16List uint16list = Uint8List.fromList(data).buffer.asUint16List();
+
+      List<double> processedList = [
+        for (var i = 0; i < uint16list.length; i++)
+          // Shift all values to between `[-32768, 32767]`
+          (fold(uint16list[i], 16) - 32768) * stem.volume // Apply volume
+      ];
+      listsToMix.add(processedList);
+    }
+
+    // Mix all byte lists into one
+    List<int> mixed = [
+      for (int i = 0; i < listsToMix.first.length; i++)
+        (listsToMix.fold(0.0, (sum, list) => sum + list[i]) / 4).round()
+    ];
+
+    // Shift all values back to between `[0, 65536]`
+    List<int> unshifted = [
+      for (var i = 0; i < mixed.length; i++) (fold(mixed[i], 16) + 32768)
+    ];
+
+    // Convert back to 8 bit
+    Uint8List uint8list = Uint16List.fromList(unshifted).buffer.asUint8List();
+
+    if (headerPresent) {
+      // Return header and then data
+      return dataLists.first.fileData.sublist(0, 44) + uint8list;
+    }
+
+    return uint8list;
+  }
 }
 
 /// Shifts int [x] of bit width [bits] up by half the total range, then wraps
 /// any overflowing values around to maintain the bit width. This is used to
 /// convert between signed and unsigned PCM.
 int fold(int x, int bits) => (x + (1 << (bits - 1))) % (1 << bits);
-
-/// Mix multiple `wav` files together by taking the average value of each byte.
-///
-/// 16 bits per sample is assumed.
-/// TODO: Check header for audio format (16, 32 bit...)
-///
-/// The wav headers (if present) are (for simplicity) also mixed, which will
-/// cause undefined behaviour if the files have different headers.
-List<int> mixWavFiles(List<StemFileData> dataLists) {
-  Demixer demixer = MusicPlayer.instance.demixer;
-  List<Stem> enabledStems =
-      demixer.stems.where((stem) => stem.enabled).toList();
-
-  double totalVolume = 0;
-  List<List<double>> listsToMix = [];
-  for (Stem stem in enabledStems) {
-    StemFileData stemFileData = dataLists
-        .where((stemFileData) => stemFileData.stemType == stem.type)
-        .first;
-
-    /// Convert byte lists from 8 bit to 16 bit.
-    Uint16List uint16list =
-        Uint8List.fromList(stemFileData.fileData).buffer.asUint16List();
-
-    List<double> processedList = [
-      for (var i = 0; i < uint16list.length; i++)
-        fold(uint16list[i], 16) // Shift all values to between `[-32768, 32767]`
-            *
-            stem.volume // Apply volume
-    ];
-
-    totalVolume += stem.volume;
-
-    listsToMix.add(processedList);
-  }
-
-  /// Mix all byte lists into one.
-  List<int> mixed = [
-    for (int i = 0; i < listsToMix.first.length; i++)
-      (listsToMix.fold(0.0, (sum, list) => sum + list[i]) / totalVolume).round()
-  ];
-
-  /// Shift all values back to between `[0, 65536]`.
-  List<int> unshifted = [
-    for (var i = 0; i < mixed.length; i++) fold(mixed[i], 16)
-  ];
-
-  /// Convert back to 8 bit.
-  Uint8List uint8list = Uint16List.fromList(unshifted).buffer.asUint8List();
-
-  return uint8list;
-}

--- a/lib/music_player/demixer/mixed_audio_source.dart
+++ b/lib/music_player/demixer/mixed_audio_source.dart
@@ -86,9 +86,10 @@ class MixedAudioSource extends StreamAudioSource {
     }
 
     // Mix all byte lists into one
+    // I thought we would need to divide the sum by 4 here, but then the volume is lowered to 1/4. Why?
     List<int> mixed = [
       for (int i = 0; i < listsToMix.first.length; i++)
-        (listsToMix.fold(0.0, (sum, list) => sum + list[i]) / 4).round()
+        listsToMix.fold(0.0, (sum, list) => sum + list[i]).round()
     ];
 
     // Shift all values back to between `[0, 65536]`

--- a/lib/music_player/demixer/mixed_audio_source.dart
+++ b/lib/music_player/demixer/mixed_audio_source.dart
@@ -3,6 +3,17 @@ import 'dart:typed_data';
 
 import 'package:async/async.dart';
 import 'package:just_audio/just_audio.dart';
+import 'package:musbx/music_player/demixer/demixer.dart';
+import 'package:musbx/music_player/demixer/host.dart';
+import 'package:musbx/music_player/demixer/stem.dart';
+import 'package:musbx/music_player/music_player.dart';
+
+class StemFileData {
+  StemFileData({required this.stemType, required this.fileData});
+
+  final StemType stemType;
+  final List<int> fileData;
+}
 
 class MixedAudioSource extends StreamAudioSource {
   /// An [AudioSource] that mixes multiple .wav files.
@@ -10,16 +21,19 @@ class MixedAudioSource extends StreamAudioSource {
   /// All [files] must have the same duration
   MixedAudioSource(this.files) : super(tag: 'MixedAudioSource');
 
-  final List<File> files;
+  final Map<StemType, File> files;
 
   @override
   Future<StreamAudioResponse> request([int? start, int? end]) async {
-    int sourceLength = await files.first.length();
+    int sourceLength = await files.values.first.length();
 
-    Iterable<Stream<List<int>>> readStreams =
-        files.map((file) => file.openRead(start, end));
+    List<Stream<StemFileData>> readStreams = files.entries
+        .map((entry) => entry.value
+            .openRead(start, end)
+            .map((data) => StemFileData(stemType: entry.key, fileData: data)))
+        .toList();
     Stream<List<int>> mixed =
-        StreamZip<List<int>>(readStreams).map(mixWavFiles);
+        StreamZip<StemFileData>(readStreams).map(mixWavFiles);
 
     return StreamAudioResponse(
       sourceLength: sourceLength,
@@ -41,26 +55,40 @@ int fold(int x, int bits) => (x + (1 << (bits - 1))) % (1 << bits);
 /// 16 bits per sample is assumed.
 /// TODO: Check header for audio format (16, 32 bit...)
 ///
-/// The wav headers (if present) are (for simplicity) also mixed, which will cause undefined
-/// behaviour if the files have different headers.
-List<int> mixWavFiles(List<List<int>> dataLists) {
-  /// Convert byte lists from 8 bit to 16 bit.
-  List<Uint16List> uint16lists = [
-    for (final data in dataLists) Uint8List.fromList(data).buffer.asUint16List()
-  ];
+/// The wav headers (if present) are (for simplicity) also mixed, which will
+/// cause undefined behaviour if the files have different headers.
+List<int> mixWavFiles(List<StemFileData> dataLists) {
+  Demixer demixer = MusicPlayer.instance.demixer;
+  List<Stem> enabledStems =
+      demixer.stems.where((stem) => stem.enabled).toList();
 
-  /// Shift all values to make them signed (between `[-32768, 32767]` instead of `[0, 65536]`).
-  List<List<int>> shiftedLists = [
-    for (final uint16list in uint16lists)
-      [for (var i = 0; i < uint16list.length; i++) fold(uint16list[i], 16)]
-  ];
+  double totalVolume = 0;
+  List<List<double>> listsToMix = [];
+  for (Stem stem in enabledStems) {
+    StemFileData stemFileData = dataLists
+        .where((stemFileData) => stemFileData.stemType == stem.type)
+        .first;
 
-  // TODO: Consider volume of each wav
+    /// Convert byte lists from 8 bit to 16 bit.
+    Uint16List uint16list =
+        Uint8List.fromList(stemFileData.fileData).buffer.asUint16List();
+
+    List<double> processedList = [
+      for (var i = 0; i < uint16list.length; i++)
+        fold(uint16list[i], 16) // Shift all values to between `[-32768, 32767]`
+            *
+            stem.volume // Apply volume
+    ];
+
+    totalVolume += stem.volume;
+
+    listsToMix.add(processedList);
+  }
 
   /// Mix all byte lists into one.
   List<int> mixed = [
-    for (int i = 0; i < shiftedLists.first.length; i++)
-      shiftedLists.fold(0.0, (sum, shiftedList) => sum + shiftedList[i]) ~/ 4
+    for (int i = 0; i < listsToMix.first.length; i++)
+      (listsToMix.fold(0.0, (sum, list) => sum + list[i]) / totalVolume).round()
   ];
 
   /// Shift all values back to between `[0, 65536]`.

--- a/lib/music_player/demixer/mixed_audio_source.dart
+++ b/lib/music_player/demixer/mixed_audio_source.dart
@@ -1,51 +1,79 @@
 import 'dart:io';
+import 'dart:typed_data';
 
-import 'package:flutter/foundation.dart';
+import 'package:async/async.dart';
 import 'package:just_audio/just_audio.dart';
-import 'package:musbx/music_player/demixer/demixer_api.dart';
-import 'package:musbx/music_player/demixer/host.dart';
-import 'package:wav/wav.dart';
 
 class MixedAudioSource extends StreamAudioSource {
   /// An [AudioSource] that mixes multiple .wav files.
   ///
-  /// All [wavs] must have the same duration
-  MixedAudioSource(this.wavs) : super(tag: 'MixedAudioSource') {
-    assert(wavs.every((wav) => wav.duration == wavs[0].duration),
-        "All wavs must have the same duration");
-  }
+  /// All [files] must have the same duration
+  MixedAudioSource(this.files) : super(tag: 'MixedAudioSource');
 
-  final List<Wav> wavs;
+  final List<File> files;
 
   @override
   Future<StreamAudioResponse> request([int? start, int? end]) async {
-    print("[DEMIXER] Request");
-    int sourceLength = (wavs[0].duration * wavs[0].samplesPerSecond).toInt();
+    print("[DEMIXER] Request ($start, $end)");
+    int sourceLength = await files.first.length();
+
+    Iterable<Stream<List<int>>> streams =
+        files.map((file) => file.openRead(start, end));
+
+    Stream<List<int>> mixed = StreamZip<List<int>>(streams).map(mixByteLists);
 
     return StreamAudioResponse(
       sourceLength: sourceLength,
       contentLength: (end ?? sourceLength) - (start ?? 0),
       offset: start ?? 0,
-      stream: Stream.fromIterable(
-          [wavs[0].channels[0].buffer.asInt64List().sublist(start ?? 0, end)]),
+      stream: mixed,
       contentType: 'audio/wav',
     );
   }
 }
 
-List<int> mixWavs(List<Wav> wavs) {
-  /// The bytes of [wavs] converted to mono.
-  List<Float64List> wavsBytes = wavs.map((wav) => wav.toMono()).toList();
+/// Shifts int [x] of bit width [bits] up by half the total range, then wraps
+/// any overflowing values around to maintain the bit width. This is used to
+/// convert between signed and unsigned PCM.
+int fold(int x, int bits) => (x + (1 << (bits - 1))) % (1 << bits);
 
-  assert(
-      wavsBytes
-          .skip(1)
-          .every((wavBytes) => wavBytes.length == wavsBytes.first.length),
-      "All wavs must have the same number of bytes");
+List<int> mixByteLists(List<List<int>> byteLists) {
+  // Assumes all headers are equal
+  // TODO: Remove "clicking" noise caused be the headers not being equal
+  List<int> header = byteLists.first.sublist(0, 44);
+  List<List<int>> contents =
+      byteLists.map((byteList) => byteList.sublist(44)).toList();
 
-  int nWavs = wavs.length;
-  return List.generate(wavsBytes.first.length, (i) {
-    // TODO: Consider volume of each wav
-    return wavsBytes.fold(0.0, (sum, wavBytes) => sum + wavBytes[i]) ~/ nWavs;
-  });
+  // TODO: Check header for audio format (16, 32 bit...)
+  // Assumes 16 bits per sample
+
+  /// Convert byte lists from 8 bit to 16 bit.
+  List<Uint16List> uint16lists = [
+    for (final content in contents)
+      Uint8List.fromList(content).buffer.asUint16List()
+  ];
+
+  /// Shift all values to make them signed (between `[-32768, 32767]` instead of `[0, 65536]`).
+  List<List<int>> shiftedLists = [
+    for (final uint16list in uint16lists)
+      [for (var i = 0; i < uint16list.length; i++) fold(uint16list[i], 16)]
+  ];
+
+  // TODO: Consider volume of each wav
+
+  /// Mix all byte lists into one.
+  List<int> mixed = [
+    for (int i = 0; i < shiftedLists.first.length; i++)
+      shiftedLists.fold(0.0, (sum, shiftedList) => sum + shiftedList[i]) ~/ 4
+  ];
+
+  /// Shift all values back to between `[0, 65536]`.
+  List<int> unshifted = [
+    for (var i = 0; i < mixed.length; i++) fold(mixed[i], 16)
+  ];
+
+  /// Convert back to 8 bit.
+  Uint8List uint8list = Uint16List.fromList(unshifted).buffer.asUint8List();
+
+  return header + uint8list;
 }

--- a/lib/music_player/demixer/mixed_audio_source.dart
+++ b/lib/music_player/demixer/mixed_audio_source.dart
@@ -10,18 +10,23 @@ import 'package:musbx/music_player/demixer/stem.dart';
 import 'package:musbx/music_player/music_player.dart';
 
 class StemFileData {
+  /// Helper class for matching data from a stem file to the type of the stem.
   StemFileData({required this.stemType, required this.fileData});
 
+  /// The type of the stem that [fileData] comes from.
   final StemType stemType;
+
+  /// Byte data from the file.
   final List<int> fileData;
 }
 
 class MixedAudioSource extends StreamAudioSource {
   /// An [AudioSource] that mixes multiple .wav files.
   ///
-  /// All [files] must have the same duration
+  /// All [files] must have the same duration.
   MixedAudioSource(this.files) : super(tag: 'MixedAudioSource');
 
+  /// The files to mix.
   final Map<StemType, File> files;
 
   @override
@@ -90,7 +95,7 @@ class MixedAudioSource extends StreamAudioSource {
     }
 
     // Mix all byte lists into one
-    // I thought we would need to divide the sum by 4 here, but then the volume is lowered to 1/4. Why?
+    // I thought we would need to divide the sum by 4 here, but then the volume is lowered. Why?
     List<int> mixed = [
       for (int i = 0; i < listsToMix.first.length; i++)
         listsToMix.fold(0.0, (sum, list) => sum + list[i]).round()

--- a/lib/music_player/demixer/stem.dart
+++ b/lib/music_player/demixer/stem.dart
@@ -1,38 +1,24 @@
 import 'package:flutter/material.dart';
-import 'package:just_audio/just_audio.dart';
 import 'package:musbx/music_player/demixer/host.dart';
-import 'package:musbx/music_player/music_player.dart';
 
 class Stem {
   /// A demixed stem for a song. Can be played back in sync with other stems.
   ///
   /// There should (usually) only ever be one stem of each [type].
-  Stem(this.type) {
-    player.volumeStream.listen((value) => volumeNotifier.value = value);
-  }
+  Stem(this.type);
 
   /// The type of stem.
   final StemType type;
 
   /// Whether this stem is enabled and should be played.
-  set enabled(bool value) {
-    if (value == false) player.pause();
-    if (value == true &&
-        MusicPlayer.instance.demixer.enabled &&
-        MusicPlayer.instance.isPlaying) player.play();
-    enabledNotifier.value = value;
-  }
-
+  set enabled(bool value) => enabledNotifier.value = value;
   bool get enabled => enabledNotifier.value;
   final ValueNotifier<bool> enabledNotifier = ValueNotifier(true);
 
   /// The volume this stem is played at. Must be between 0 and 1.
-  set volume(double value) => player.setVolume(value.clamp(0, 1));
+  set volume(double value) => volumeNotifier.value = value;
   double get volume => volumeNotifier.value;
   final ValueNotifier<double> volumeNotifier = ValueNotifier(0.5);
-
-  /// The player used internally for playback.
-  late final AudioPlayer player = AudioPlayer()..setVolume(volume);
 }
 
 class StemsNotifier extends ValueNotifier<List<Stem>> {

--- a/lib/music_player/demixer/stem.dart
+++ b/lib/music_player/demixer/stem.dart
@@ -3,7 +3,7 @@ import 'package:musbx/music_player/demixer/host.dart';
 
 class Stem {
   /// The default [volume]
-  static const defaultVolume = 1.0;
+  static const defaultVolume = 0.5;
 
   /// A demixed stem for a song. Can be played back in sync with other stems.
   ///

--- a/lib/music_player/demixer/stem.dart
+++ b/lib/music_player/demixer/stem.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:musbx/music_player/demixer/host.dart';
 
 class Stem {
+  /// The default [volume]
+  static const defaultVolume = 1.0;
+
   /// A demixed stem for a song. Can be played back in sync with other stems.
   ///
   /// There should (usually) only ever be one stem of each [type].
@@ -18,7 +21,7 @@ class Stem {
   /// The volume this stem is played at. Must be between 0 and 1.
   set volume(double value) => volumeNotifier.value = value;
   double get volume => volumeNotifier.value;
-  final ValueNotifier<double> volumeNotifier = ValueNotifier(0.5);
+  final ValueNotifier<double> volumeNotifier = ValueNotifier(defaultVolume);
 }
 
 class StemsNotifier extends ValueNotifier<List<Stem>> {

--- a/lib/music_player/equalizer/equalizer.dart
+++ b/lib/music_player/equalizer/equalizer.dart
@@ -31,10 +31,10 @@ class Equalizer extends MusicPlayerComponent {
   void initialize(MusicPlayer musicPlayer) {
     if (Platform.isIOS) return; // TODO: Implement Equalizer on iOS
 
-    enabled = false;
     enabledNotifier.addListener(() {
       androidEqualizer.setEnabled(enabled);
     });
+    androidEqualizer.setEnabled(enabled); // Trigger initial enable
 
     androidEqualizer.parameters.then(
       (value) {

--- a/lib/music_player/equalizer/equalizer.dart
+++ b/lib/music_player/equalizer/equalizer.dart
@@ -42,12 +42,6 @@ class Equalizer extends MusicPlayerComponent {
         resetGain();
       },
     );
-
-    musicPlayer.demixer.enabledNotifier.addListener(() {
-      // For now, disable when demixer is enabled since they don't work together.
-      // TODO: Get the Demixer to work with the Equalizer.
-      if (musicPlayer.demixer.enabled) enabled = false;
-    });
   }
 
   /// Load settings from a [json] map.

--- a/lib/music_player/equalizer/equalizer_sliders.dart
+++ b/lib/music_player/equalizer/equalizer_sliders.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:just_audio/just_audio.dart';
+import 'package:musbx/music_player/demixer/stem.dart';
 import 'package:musbx/music_player/equalizer/equalizer.dart';
 import 'package:musbx/music_player/equalizer/equalizer_overlay.dart';
 import 'package:musbx/music_player/equalizer/inactive_slider_track_shape.dart';
@@ -59,7 +60,7 @@ class EqualizerSliders extends StatelessWidget {
           child: Slider(
             min: equalizer.parameters?.minDecibels ?? 0,
             max: equalizer.parameters?.maxDecibels ?? 1,
-            value: band?.gain ?? 0.5,
+            value: band?.gain ?? Stem.defaultVolume,
             onChanged: !enabled ? null : band?.setGain,
           ),
         );

--- a/lib/music_player/music_player.dart
+++ b/lib/music_player/music_player.dart
@@ -125,12 +125,12 @@ class MusicPlayer {
 
   final Demixer demixer = Demixer();
 
-  /// The song currently loading, or `null` if no song has been loaded.
+  /// The process currently loading a song, or `null` if no song has been loaded.
   ///
   /// This is used to make sure two processes don't try to load a song at the same time.
   /// Every process wanting to set [player]'s audio source must:
-  ///  1. Create a future that first awaits [futureSongLock] and then sets [player]'s audio source.
-  ///  2. Overrite [futureSongLock] with the newly created future.
+  ///  1. Create a future that first awaits [loadSongLock] and then sets [player]'s audio source.
+  ///  2. Overrite [loadSongLock] with the newly created future.
   ///  3. Await the future it created.
   ///
   /// Here is an example of how that could be done:
@@ -147,20 +147,20 @@ class MusicPlayer {
   /// }
   ///
   /// ```
-  Future<void>? futureSongLock;
+  Future<void>? loadSongLock;
 
   /// Load a [song].
   ///
   /// Prepares for playing the audio provided by [Song.source], and updates the media player notification.
   Future<void> loadSong(Song song) async {
     // Make sure no other process is currently setting the audio source
-    Future<void>? awaitBeforeLoading = futureSongLock;
-    futureSongLock = _loadSong(song, awaitBeforeLoading: awaitBeforeLoading);
-    await futureSongLock;
+    Future<void>? awaitBeforeLoading = loadSongLock;
+    loadSongLock = _loadSong(song, awaitBeforeLoading: awaitBeforeLoading);
+    await loadSongLock;
   }
 
   /// Awaits [awaitBeforeLoading] and then loads [song].
-  /// See [futureSongLock] for more info why this is required.
+  /// See [loadSongLock] for more info why this is required.
   Future<void> _loadSong(
     Song song, {
     Future<void>? awaitBeforeLoading,

--- a/lib/music_player/music_player.dart
+++ b/lib/music_player/music_player.dart
@@ -125,10 +125,47 @@ class MusicPlayer {
 
   final Demixer demixer = Demixer();
 
+  /// The song currently loading, or `null` if no song has been loaded.
+  ///
+  /// This is used to make sure two processes don't try to load a song at the same time.
+  /// Every process wanting to set [player]'s audio source must:
+  ///  1. Create a future that first awaits [futureSongLock] and then sets [player]'s audio source.
+  ///  2. Overrite [futureSongLock] with the newly created future.
+  ///  3. Await the future it created.
+  ///
+  /// Here is an example of how that could be done:
+  /// ```
+  /// Future<void> loadAudioSource() async {
+  ///   Future<void>? awaitBeforeLoading = futureSongLoading;
+  ///   futureSongLoading = _loadAudioSource(awaitBeforeLoading);
+  ///   await futureSongLoading;
+  /// }
+  ///
+  /// Future<void> _loadAudioSource(Future<void>? awaitBeforeLoading) async {
+  ///   await awaitBeforeLoading;
+  ///   await player.setAudioSource(...)
+  /// }
+  ///
+  /// ```
+  Future<void>? futureSongLock;
+
   /// Load a [song].
   ///
-  /// Prepares for playing the audio provided by [Song.audioSource], and updates the media player notification.
+  /// Prepares for playing the audio provided by [Song.source], and updates the media player notification.
   Future<void> loadSong(Song song) async {
+    // Make sure no other process is currently setting the audio source
+    Future<void>? awaitBeforeLoading = futureSongLock;
+    futureSongLock = _loadSong(song, awaitBeforeLoading: awaitBeforeLoading);
+    await futureSongLock;
+  }
+
+  /// Awaits [awaitBeforeLoading] and then loads [song].
+  /// See [futureSongLock] for more info why this is required.
+  Future<void> _loadSong(
+    Song song, {
+    Future<void>? awaitBeforeLoading,
+  }) async {
+    await awaitBeforeLoading;
     await pause();
     stateNotifier.value = MusicPlayerState.loadingAudio;
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -42,7 +42,7 @@ packages:
     source: hosted
     version: "2.4.2"
   async:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: async
       sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1045,6 +1045,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  wav:
+    dependency: "direct main"
+    description:
+      name: wav
+      sha256: ca53b6b494bbe37984dd3c7262294938b6d7a362b0f434f4c534f1ebb459f8be
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   web_socket_channel:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: "direct main"
     description:
       name: advanced_in_app_review
-      sha256: "7b544b1224d4c5b6fe0b204fdc06d47e573580c43746718b04c2be89f97e3897"
+      sha256: "5c157809877b4106fcb8e07e5bc4abbae8b5abe3fe604fb038b92c71fa7607fb"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0"
   analyzer:
     dependency: transitive
     description:
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: "0c8368c9b3f0abbc193b9d6133649a614204b528982bebc7026372d61677ce3a"
+      sha256: e0902a06f0e00414e4e3438a084580161279f137aeb862274710f29ec10cf01e
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.7"
+    version: "3.3.9"
   args:
     dependency: transitive
     description:
@@ -53,18 +53,18 @@ packages:
     dependency: "direct main"
     description:
       name: audio_service
-      sha256: "8b719ac7982fdea1a54a528f19e345907295489c53709ba4cdee65a2955c0f4d"
+      sha256: a4d989f1225ea9621898d60f23236dcbfc04876fa316086c23c5c4af075dbac4
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.10"
+    version: "0.18.12"
   audio_service_platform_interface:
     dependency: transitive
     description:
       name: audio_service_platform_interface
-      sha256: "2c3a1d52803931e836b9693547a71c0c3585ad54219d2214219ed5cfcc3c1af4"
+      sha256: "8431a455dac9916cc9ee6f7da5620a666436345c906ad2ebb7fa41d18b3c1bf4"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.0"
+    version: "0.1.1"
   audio_service_web:
     dependency: transitive
     description:
@@ -125,18 +125,18 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.17.2"
   connectivity_plus:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: "8599ae9edca5ff96163fca3e36f8e481ea917d1e71cdad912c084b5579913f34"
+      sha256: "77a180d6938f78ca7d2382d2240eb626c0f6a735d0bfdce227d8ffb80f95c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.1"
+    version: "4.0.2"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -189,10 +189,10 @@ packages:
     dependency: "direct main"
     description:
       name: device_info_plus
-      sha256: "2c35b6d1682b028e42d07b3aee4b98fa62996c10bc12cb651ec856a80d6a761b"
+      sha256: "86add5ef97215562d2e090535b0a16f197902b10c369c558a100e74ea06e8659"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.2"
+    version: "9.0.3"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -205,10 +205,10 @@ packages:
     dependency: "direct main"
     description:
       name: dynamic_color
-      sha256: "74dff1435a695887ca64899b8990004f8d1232b0e84bfc4faa1fdda7c6f57cc1"
+      sha256: "96bff3df72e3d428bda2b874c7a521e8c86f592cae626ea594922fcc8d166e0c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.5"
+    version: "1.6.7"
   fake_async:
     dependency: transitive
     description:
@@ -221,10 +221,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: ed5337a5660c506388a9f012be0288fb38b49020ce2b45fe1f8b8323fe429f99
+      sha256: "7bf0adc28a23d395f19f3f1eb21dd7cfd1dd9f8e1c50051c069122e6853bc878"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.1.0"
   file:
     dependency: transitive
     description:
@@ -237,10 +237,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: b1729fc96627dd44012d0a901558177418818d6bd428df59dcfeb594e5f66432
+      sha256: be325344c1f3070354a1d84a231a1ba75ea85d413774ec4bdf444c023342e030
       url: "https://pub.dev"
     source: hosted
-    version: "5.3.2"
+    version: "5.5.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -250,18 +250,18 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_audio_capture
-      sha256: "101a76c9a8c227901cb823306078c71391cb7d1c27cc5b7f66c06ca4dd75bff0"
+      sha256: cca8761c4192d2a8e478338d0f397e903e451899f19e012ab132eae9cb7884cf
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.4"
+    version: "1.1.6"
   flutter_cache_manager:
     dependency: transitive
     description:
       name: flutter_cache_manager
-      sha256: "32cd900555219333326a2d0653aaaf8671264c29befa65bbd9856d204a4c9fb3"
+      sha256: "8207f27539deb83732fdda03e259349046a39a4c767269285f449ade355d54ba"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0"
+    version: "3.3.1"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -274,18 +274,18 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      sha256: a25a15ebbdfc33ab1cd26c63a6ee519df92338a9c10f122adda92938253bef04
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.3"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: "950e77c2bbe1692bc0874fc7fb491b96a4dc340457f4ea1641443d0a6c1ea360"
+      sha256: f185ac890306b5779ecbd611f52502d8d4d63d27703ef73161ca0407e815f02c
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.15"
+    version: "2.0.16"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -300,10 +300,10 @@ packages:
     dependency: transitive
     description:
       name: freezed_annotation
-      sha256: aeac15850ef1b38ee368d4c53ba9a847e900bb2c53a4db3f6881cbb3cb684338
+      sha256: c3fd9336eb55a38cc1bbd79ab17573113a8deccd0ecbbf926cca3c62803b5c2d
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.1"
   frontend_server_client:
     dependency: transitive
     description:
@@ -348,10 +348,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
+      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.6"
+    version: "1.1.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -420,10 +420,10 @@ packages:
     dependency: "direct main"
     description:
       name: just_audio
-      sha256: "890cd0fc41a1a4530c171e375a2a3fb6a09d84e9d508c5195f40bcff54330327"
+      sha256: "5ed0cd723e17dfd8cd4b0253726221e67f6546841ea4553635cf895061fc335b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.34"
+    version: "0.9.35"
   just_audio_platform_interface:
     dependency: transitive
     description:
@@ -460,18 +460,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
@@ -524,10 +524,10 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: ceb027f6bc6a60674a233b4a90a7658af1aebdea833da0b5b53c1e9821a78c7b
+      sha256: "6ff267fcd9d48cb61c8df74a82680e8b82e940231bb5f68356672fde0397334a"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.1.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -548,98 +548,90 @@ packages:
     dependency: "direct main"
     description:
       name: path_provider
-      sha256: "3087813781ab814e4157b172f1a11c46be20179fcc9bea043e0fba36bc0acaa2"
+      sha256: a1aa8aaa2542a6bc57e381f132af822420216c80d4781f7aa085ca3229208aaa
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.15"
+    version: "2.1.1"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "2cec049d282c7f13c594b4a73976b0b4f2d7a1838a6dd5aaf7bd9719196bee86"
+      sha256: "6b8b19bd80da4f11ce91b2d1fb931f3006911477cec227cce23d3253d80df3f1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.27"
+    version: "2.2.0"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: "1995d88ec2948dac43edf8fe58eb434d35d22a2940ecee1a9fefcd62beee6eb3"
+      sha256: "19314d595120f82aca0ba62787d58dde2cc6b5df7d2f0daf72489e38d1b57f2d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.3"
+    version: "2.3.1"
   path_provider_linux:
     dependency: transitive
     description:
       name: path_provider_linux
-      sha256: ffbb8cc9ed2c9ec0e4b7a541e56fd79b138e8f47d2fb86815f15358a349b3b57
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.11"
+    version: "2.2.1"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      sha256: "57585299a729335f1298b43245842678cb9f43a6310351b18fb577d6e33165ec"
+      sha256: "94b1e0dd80970c1ce43d5d4e050a9918fce4f4a775e6142424c30a29a363265c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.6"
+    version: "2.1.1"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
-      sha256: "1cb68ba4cd3a795033de62ba1b7b4564dace301f952de6bfb3cd91b202b6ee96"
+      sha256: "8bc9f22eee8690981c22aa7fc602f5c85b497a6fb2ceb35ee5a5e5ed85ad8170"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.7"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.11.1"
+    version: "2.2.1"
   permission_handler:
     dependency: "direct main"
     description:
       name: permission_handler
-      sha256: "1b6b3e73f0bcbc856548bbdfb1c33084a401c4f143e220629a9055233d76c331"
+      sha256: bc56bfe9d3f44c3c612d8d393bd9b174eb796d706759f9b495ac254e4294baa5
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.0"
+    version: "10.4.5"
   permission_handler_android:
     dependency: transitive
     description:
       name: permission_handler_android
-      sha256: "8f6a95ccbca13766882f95d32684d7c9bfe6c45650c32bedba948ef1c6a4ddf7"
+      sha256: "59c6322171c29df93a22d150ad95f3aa19ed86542eaec409ab2691b8f35f9a47"
       url: "https://pub.dev"
     source: hosted
-    version: "10.2.3"
+    version: "10.3.6"
   permission_handler_apple:
     dependency: transitive
     description:
       name: permission_handler_apple
-      sha256: "08dcb6ce628ac0b257e429944b4c652c2a4e6af725bdf12b498daa2c6b2b1edb"
+      sha256: "99e220bce3f8877c78e4ace901082fb29fa1b4ebde529ad0932d8d664b34f3f5"
       url: "https://pub.dev"
     source: hosted
-    version: "9.1.0"
+    version: "9.1.4"
   permission_handler_platform_interface:
     dependency: transitive
     description:
       name: permission_handler_platform_interface
-      sha256: de20a5c3269229c1ae2e5a6b822f6cb59578b23e8255c93fbeebfc82116e6b11
+      sha256: f2343e9fa9c22ae4fd92d4732755bfe452214e7189afcc097380950cf567b4b2
       url: "https://pub.dev"
     source: hosted
-    version: "3.10.0"
+    version: "3.11.5"
   permission_handler_windows:
     dependency: transitive
     description:
       name: permission_handler_windows
-      sha256: f67cab14b4328574938ecea2db3475dad7af7ead6afab6338772c5f88963e38b
+      sha256: cc074aace208760f1eee6aa4fae766b45d947df85bc831cde77009cdb4720098
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.2"
+    version: "0.1.3"
   petitparser:
     dependency: transitive
     description:
@@ -660,18 +652,18 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
+      sha256: ae68c7bfcd7383af3629daafb32fb4e8681c7154428da4febcff06200585f102
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.2"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      sha256: "6a2128648c854906c53fa8e33986fc0247a1116122f9534dd20e3ab9e16a32bc"
+      sha256: da3fdfeccc4d4ff2da8f8c556704c08f912542c5fb3cf2233ed75372384a034d
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.6"
   pointycastle:
     dependency: transitive
     description:
@@ -688,14 +680,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
-  process:
-    dependency: transitive
-    description:
-      name: process
-      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.2.4"
   pub_semver:
     dependency: transitive
     description:
@@ -716,58 +700,58 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences
-      sha256: "396f85b8afc6865182610c0a2fc470853d56499f75f7499e2a73a9f0539d23d0"
+      sha256: b7f41bad7e521d205998772545de63ff4e6c97714775902c199353f8bf1511ac
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.2.1"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "6478c6bbbecfe9aced34c483171e90d7c078f5883558b30ec3163cf18402c749"
+      sha256: "8568a389334b6e83415b6aae55378e158fbc2314e074983362d20c562780fb06"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.1"
   shared_preferences_foundation:
     dependency: transitive
     description:
       name: shared_preferences_foundation
-      sha256: e014107bb79d6d3297196f4f2d0db54b5d1f85b8ea8ff63b8e8b391a02700feb
+      sha256: "7bf53a9f2d007329ee6f3df7268fd498f8373602f943c975598bbb34649b62a7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.2"
+    version: "2.3.4"
   shared_preferences_linux:
     dependency: transitive
     description:
       name: shared_preferences_linux
-      sha256: "9d387433ca65717bbf1be88f4d5bb18f10508917a8fa2fb02e0fd0d7479a9afa"
+      sha256: c2eb5bf57a2fe9ad6988121609e47d3e07bb3bdca5b6f8444e4cf302428a128a
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.1"
   shared_preferences_platform_interface:
     dependency: transitive
     description:
       name: shared_preferences_platform_interface
-      sha256: fb5cf25c0235df2d0640ac1b1174f6466bd311f621574997ac59018a6664548d
+      sha256: d4ec5fc9ebb2f2e056c617112aa75dcf92fc2e4faaf2ae999caa297473f75d8a
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.1"
   shared_preferences_web:
     dependency: transitive
     description:
       name: shared_preferences_web
-      sha256: "74083203a8eae241e0de4a0d597dbedab3b8fef5563f33cf3c12d7e93c655ca5"
+      sha256: d762709c2bbe80626ecc819143013cc820fa49ca5e363620ee20a8b15a3e3daf
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.1"
   shared_preferences_windows:
     dependency: transitive
     description:
       name: shared_preferences_windows
-      sha256: "5e588e2efef56916a3b229c3bfe81e6a525665a454519ca51dbcc4236a274173"
+      sha256: f763a101313bd3be87edffe0560037500967de9c394a714cd598d945517f694f
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.1"
   shelf:
     dependency: transitive
     description:
@@ -809,34 +793,34 @@ packages:
     dependency: "direct main"
     description:
       name: soundpool
-      sha256: "4aa6b4950e7853dc7f6318234f12c6f27fe1fa8ee55a002ce7d158bc927f6129"
+      sha256: fe7302005759d6a3561de1711e3ea818b1ba025a62375b469196dda5b654bd38
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.4.1"
   soundpool_macos:
     dependency: transitive
     description:
       name: soundpool_macos
-      sha256: dd389a629d32e3960fbe55958f2f7e03e074c4987fadf38fbe6c7e0a1ba32528
+      sha256: e0440a19d4e8f344dace336923b369184e91eebbbd8348266f4434b675bd15db
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.0"
   soundpool_platform_interface:
     dependency: transitive
     description:
       name: soundpool_platform_interface
-      sha256: "9787f96b54a12e236cd3715cd2cc4bcd1fc1131e834ea7b295ac849ab4e24eab"
+      sha256: "7c6666e19319151b2036c4fc9b6da3a83f2ebf4097989e6ba1c2b0bfe3612e9f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   soundpool_web:
     dependency: transitive
     description:
       name: soundpool_web
-      sha256: "5242ebd135c210e6b4239fb2409f2da91af688358e3070c9c33ea625d85b7d22"
+      sha256: "3d1eb8d6cceb8a0aec38ff9aec4fbd11a9a8101d27b27a6eb29305b83d46aee5"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.0"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -857,26 +841,34 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
+  sprintf:
+    dependency: transitive
+    description:
+      name: sprintf
+      sha256: "1fc9ffe69d4df602376b52949af107d8f5703b77cda567c4d7d86a0693120f23"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
   sqflite:
     dependency: transitive
     description:
       name: sqflite
-      sha256: b4d6710e1200e96845747e37338ea8a819a12b51689a3bcf31eff0003b37a0b9
+      sha256: "591f1602816e9c31377d5f008c2d9ef7b8aca8941c3f89cc5fd9d84da0c38a9a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.8+4"
+    version: "2.3.0"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "8f7603f3f8f126740bc55c4ca2d1027aab4b74a1267a3e31ce51fe40e3b65b8f"
+      sha256: "1b92f368f44b0dee2425bb861cfa17b6f6cf3961f762ff6f941d20b33355660a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.5+1"
+    version: "2.5.0"
   stack_trace:
     dependency: transitive
     description:
@@ -921,26 +913,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "3dac9aecf2c3991d09b9cdde4f98ded7b30804a88a0d7e4e7e1678e78d6b97f4"
+      sha256: "13b41f318e2a5751c3169137103b60c584297353d4b1761b66029bae6411fe46"
       url: "https://pub.dev"
     source: hosted
-    version: "1.24.1"
+    version: "1.24.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.0"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "5138dbffb77b2289ecb12b81c11ba46036590b72a64a7a90d6ffb880f1a29e93"
+      sha256: "99806e9e6d95c7b059b7a0fc08f07fc53fabe54a829497f0d9676299f1e8637e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.5.3"
   typed_data:
     dependency: transitive
     description:
@@ -953,74 +945,74 @@ packages:
     dependency: transitive
     description:
       name: url_launcher
-      sha256: eb1e00ab44303d50dd487aab67ebc575456c146c6af44422f9c13889984c00f3
+      sha256: "47e208a6711459d813ba18af120d9663c20bdf6985d6ad39fe165d2538378d27"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.11"
+    version: "6.1.14"
   url_launcher_android:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "15f5acbf0dce90146a0f5a2c4a002b1814a6303c4c5c075aa2623b2d16156f03"
+      sha256: b04af59516ab45762b2ca6da40fa830d72d0f6045cd97744450b73493fa76330
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.36"
+    version: "6.1.0"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: "9af7ea73259886b92199f9e42c116072f05ff9bea2dcb339ab935dfc957392c2"
+      sha256: "7c65021d5dee51813d652357bc65b8dd4a6177082a9966bc8ba6ee477baa795f"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "6.1.5"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
-      sha256: "207f4ddda99b95b4d4868320a352d374b0b7e05eefad95a4a26f57da413443f5"
+      sha256: b651aad005e0cb06a01dbd84b428a301916dc75f0e7ea6165f80057fee2d8e8e
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.6"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: "91ee3e75ea9dadf38036200c5d3743518f4a5eb77a8d13fda1ee5764373f185e"
+      sha256: b55486791f666e62e0e8ff825e58a023fd6b1f71c49926483f1128d3bbd8fe88
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.7"
   url_launcher_platform_interface:
     dependency: transitive
     description:
       name: url_launcher_platform_interface
-      sha256: bfdfa402f1f3298637d71ca8ecfe840b4696698213d5346e9d12d4ab647ee2ea
+      sha256: "95465b39f83bfe95fcb9d174829d6476216f2d548b79c38ab2506e0458787618"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.5"
   url_launcher_web:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: "6bb1e5d7fe53daf02a8fee85352432a40b1f868a81880e99ec7440113d5cfcab"
+      sha256: "2942294a500b4fa0b918685aff406773ba0a4cd34b7f42198742a94083020ce5"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.17"
+    version: "2.0.20"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: "254708f17f7c20a9c8c471f67d86d76d4a3f9c1591aad1e15292008aceb82771"
+      sha256: "95fef3129dc7cfaba2bc3d5ba2e16063bb561fc6d78e63eee16162bc70029069"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.6"
+    version: "3.0.8"
   uuid:
     dependency: transitive
     description:
       name: uuid
-      sha256: "648e103079f7c64a36dc7d39369cabb358d377078a051d6ae2ad3aa539519313"
+      sha256: e03928880bdbcbf496fb415573f5ab7b1ea99b9b04f669c01104d085893c3134
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.7"
+    version: "4.0.0"
   vector_math:
     dependency: transitive
     description:
@@ -1033,10 +1025,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b8c67f5fa3897b122cf60fe9ff314f7b0ef71eab25c5f8b771480bc338f48823
+      sha256: c538be99af830f478718b51630ec1b6bee5e74e52c8a802d328d9e71d35d2583
       url: "https://pub.dev"
     source: hosted
-    version: "11.7.2"
+    version: "11.10.0"
   watcher:
     dependency: transitive
     description:
@@ -1045,6 +1037,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
   web_socket_channel:
     dependency: transitive
     description:
@@ -1057,34 +1057,34 @@ packages:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      sha256: "67d3a8b6c79e1987d19d848b0892e582dbb0c66c57cc1fef58a177dd2aa2823d"
+      sha256: "87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   win32:
     dependency: transitive
     description:
       name: win32
-      sha256: "1414f27dd781737e51afa9711f2ac2ace6ab4498ee98e20863fa5505aa00c58c"
+      sha256: c97defd418eef4ec88c0d1652cdce84b9f7b63dd7198e266d06ac1710d527067
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.4"
+    version: "5.0.8"
   win32_registry:
     dependency: transitive
     description:
       name: win32_registry
-      sha256: e4506d60b7244251bc59df15656a3093501c37fb5af02105a944d73eb95be4c9
+      sha256: "41fd8a189940d8696b1b810efb9abcf60827b6cbfab90b0c43e8439e3a39d85a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
-      sha256: ee1505df1426458f7f60aac270645098d318a8b4766d85fde75f76f2e21807d1
+      sha256: "589ada45ba9e39405c198fe34eb0f607cddb2108527e658136120892beac46d2"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.3"
   xml:
     dependency: transitive
     description:
@@ -1105,10 +1105,10 @@ packages:
     dependency: "direct main"
     description:
       name: youtube_explode_dart
-      sha256: "07889a6229a63e78f8d45a3b852897c2e0fa42e96c4daa38d411be211575bc38"
+      sha256: "98fd11b51adbbca76cbdb17f560168f1d7a9835cecceea965f49eb1e5eed155c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.4"
+    version: "2.0.2"
 sdks:
-  dart: ">=3.0.0 <4.0.0"
-  flutter: ">=3.4.0-17.0.pre"
+  dart: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1045,14 +1045,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
-  wav:
-    dependency: "direct main"
-    description:
-      name: wav
-      sha256: ca53b6b494bbe37984dd3c7262294938b6d7a362b0f434f4c534f1ebb459f8be
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.0"
   web_socket_channel:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,18 +45,18 @@ dependencies:
   just_audio: ^0.9.31
   audio_service: ^0.18.9
   file_picker: ^5.2.5
-  http: ^0.13.6
-  youtube_explode_dart: ^1.12.3
+  http: ^1.1.0
+  youtube_explode_dart: ^2.0.2
   html_unescape: ^2.0.0
   http_parser: ^4.0.2
   connectivity_plus: ^4.0.1
+  async: ^2.11.0
 
   #Tuner
   pitch_detector_dart: ^0.0.2
   flutter_audio_capture: ^1.1.4
   mic_stream: ^0.6.4
   gauges: ^1.0.0
-  async: ^2.11.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,7 @@ dependencies:
   flutter_audio_capture: ^1.1.4
   mic_stream: ^0.6.4
   gauges: ^1.0.0
+  wav: ^1.3.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,6 +57,7 @@ dependencies:
   mic_stream: ^0.6.4
   gauges: ^1.0.0
   wav: ^1.3.0
+  async: ^2.11.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,20 +42,20 @@ dependencies:
   soundpool: ^2.3.0
   
   # Music player
-  just_audio: ^0.9.31
-  audio_service: ^0.18.9
-  file_picker: ^5.2.5
+  just_audio: ^0.9.35
+  audio_service: ^0.18.12
+  file_picker: ^5.5.0
   http: ^1.1.0
   youtube_explode_dart: ^2.0.2
   html_unescape: ^2.0.0
   http_parser: ^4.0.2
-  connectivity_plus: ^4.0.1
+  connectivity_plus: ^4.0.2
   async: ^2.11.0
 
   #Tuner
   pitch_detector_dart: ^0.0.2
-  flutter_audio_capture: ^1.1.4
-  mic_stream: ^0.6.4
+  flutter_audio_capture: ^1.1.6
+  mic_stream: ^0.6.5
   gauges: ^1.0.0
 
   # The following adds the Cupertino Icons font to your application.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,7 +56,6 @@ dependencies:
   flutter_audio_capture: ^1.1.4
   mic_stream: ^0.6.4
   gauges: ^1.0.0
-  wav: ^1.3.0
   async: ^2.11.0
 
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
For the Demixer's playback, create an AudioSource that mixes multiple wav files instead of using one AudioPlayer per stem. 

This fixes maximum resource limit being exceeded on iOS, and eliminates a lot of problems with syncing the different AudioPlayers, but has the disadvantage that there is a short delay when toggling or changing the volume of stems.
It also enables the Equalized and the Demixer to be used simultaneously.